### PR TITLE
remove resizing jank in the hero on mobile devices

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -20,6 +20,7 @@ img:
 typeform-link: "https://adicu.typeform.com/to/VtGJY1"
 
 js:
+  mobile-detect: "/js/lib/mobile-detect.min.js"
   jquery-cdn: "https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"
   index: "/js/index.js"
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+
   var w = $(window);
 
   if (w.scrollTop() > 0) {
@@ -15,6 +16,7 @@ $(document).ready(function() {
   });
 
   var vh = window.innerHeight;
+  var landingPage = $('.landing-page');
   var lion = $('#lion');
   var _height = 40;
   var _left = 50;
@@ -69,6 +71,35 @@ $(document).ready(function() {
       $.scrollTo(0, 500);
     })
   });
+
+  var md = new MobileDetect(window.navigator.userAgent);
+  if (md.mobile() !== null) {
+    // On mobile devices, freeze the hero.
+    freezeHero();
+    w.on('orientationchange', updateHero);
+  }
+
+  function freezeHero() {
+    // Set landing page height to pixel value.
+    landingPage.css({
+      height: landingPage.height()
+    });
+
+    // Set lion size / position to pixel value.
+    lion.css({
+      height: lion.height(),
+      top: lion.css('top')
+    });
+  }
+
+  function updateHero() {
+    // reset lion and landing page to initial values so they can resize
+    landingPage.removeAttr('style');
+    lion.removeAttr('style');
+
+    // then when everything has been layed out again, freeze at the new sizes
+    setTimeout(freezeHero, 500);
+  }
 
   function _easeInOutQuad(x, t, b, c, d) {
     if ((t /= d / 2) < 1) return c / 2 * t * t + b;

--- a/src/partials/base.hbs
+++ b/src/partials/base.hbs
@@ -60,6 +60,7 @@
         ga('create', '{{ meta.google_analytics_id }}', 'auto');
         ga('send', 'pageview');
     </script>
+    <script src="{{js.mobile-detect}}"></script>
     <script src="{{js.jquery-cdn}}"></script>
     <script src="{{js.index}}"></script>
 </head>


### PR DESCRIPTION
Videos here:
https://goo.gl/photos/jr38F6DeB1nEWu7V8

Fixes jank in the hero when mobile browsers scroll away the URL bar. It's caused by the landing page and lion being sized / positions in percentages (100% height, 40% height, 45% top, etc).

The solution is to set their sizes to pixels in Javascript (remembering to update on orientation changes).  

This is only done on mobile devices, using mobile detect (included in the project template already).